### PR TITLE
Add Blade support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ By [wpprotools.io](https://www.wpprotools.io/)
 ## Requirements
 
 These snippets are bound to the PHP language context. Your cursor will need to be inside a set of PHP tags.
+
+They also will work with the Blade language addev by the [laravel-blade](https://marketplace.visualstudio.com/items?itemName=cjhowe7.laravel-blade) extension.

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
                 "language": "php",
                 "path": "./snippets/snippets.json"
             },
-			{
-				"language": "blade",
-				"path": "./snippets/snippets.json"
-			}
+            {
+                "language": "blade",
+                "path": "./snippets/snippets.json"
+            }
         ]
     },
     "icon": "images/wpprotools-icon.png",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
             {
                 "language": "php",
                 "path": "./snippets/snippets.json"
-            }
+            },
+			{
+				"language": "blade",
+				"path": "./snippets/snippets.json"
+			}
         ]
     },
     "icon": "images/wpprotools-icon.png",


### PR DESCRIPTION
For developers working with a Laravel integrated theme (like [Sage](https://roots.io/sage/)), it would be nice to also support these snippets in Blade files.

The Blade language can be added to VS code by the [laravel-blade](https://marketplace.visualstudio.com/items?itemName=cjhowe7.laravel-blade) extension.

I have tested by using this version locally and the snippets and shortcuts work as would be expected.